### PR TITLE
Add productId to sign response

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
@@ -93,7 +93,7 @@ class QuoteServiceImpl(
             is Either.Right -> {
 
                 Either.Right(SignResponseDTO(requestId = request.requestId,
-                        quoteId = response.b.id, signedAt = response.b.signedAt.epochSecond))
+                        quoteId = response.b.id, productId = response.b.id, signedAt = response.b.signedAt.epochSecond))
             }
             is Either.Left -> {
                 return when (response.a.errorCode) {

--- a/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/SignResponseDTO.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/SignResponseDTO.kt
@@ -2,6 +2,7 @@ package com.hedvig.rapio.quotes.web.dto
 
 data class SignResponseDTO(
         val requestId: String,
+        @Deprecated("This has the same value as productId, so use that instead", level = DeprecationLevel.ERROR)
         val quoteId: String,
         val productId: String,
         val signedAt: Long

--- a/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/SignResponseDTO.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/SignResponseDTO.kt
@@ -3,5 +3,6 @@ package com.hedvig.rapio.quotes.web.dto
 data class SignResponseDTO(
         val requestId: String,
         val quoteId: String,
+        val productId: String,
         val signedAt: Long
 )

--- a/src/test/kotlin/com/hedvig/rapio/quotes/web/QuotesControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/quotes/web/QuotesControllerTest.kt
@@ -135,7 +135,7 @@ internal class QuotesControllerTest {
     fun sign_quote(){
 
         val id = UUID.randomUUID()
-        every { quoteService.signQuote(id, any()) } returns Right(SignResponseDTO("jl", id.toString(), Instant.now().epochSecond))
+        every { quoteService.signQuote(id, any()) } returns Right(SignResponseDTO("jl", id.toString(), id.toString(), Instant.now().epochSecond))
 
         val request = post("/v1/quotes/$id/sign")
                 .with(user("compricer"))


### PR DESCRIPTION
For some reason we called productId quoteId. So I created a new field
with a better name and keept the old one for backwards compatability.