### PR TITLE
Deprecated HOME and HOUSE product types in quote request

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/QuoteRequestDTO.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/QuoteRequestDTO.kt
@@ -13,8 +13,10 @@ data class QuoteRequestDTO(
     @get: Valid val productType: ProductType,
     @set:JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "productType")
     @JsonSubTypes(
-            JsonSubTypes.Type(value = com.hedvig.rapio.quotes.web.dto.ApartmentQuoteRequestData::class, name = "HOME"),
-            JsonSubTypes.Type(value = com.hedvig.rapio.quotes.web.dto.HouseQuoteRequestData::class, name = "HOUSE")
+            JsonSubTypes.Type(value = ApartmentQuoteRequestData::class, name = "SWEDISH_APARTMENT"),
+            JsonSubTypes.Type(value = HouseQuoteRequestData::class, name = "SWEDISH_HOUSE"),
+            JsonSubTypes.Type(value = ApartmentQuoteRequestData::class, name = "HOME"), // Deprecated use SWEDISH_APARTMENT
+            JsonSubTypes.Type(value = HouseQuoteRequestData::class, name = "HOUSE")  // Deprecated use SWEDISH_HOUSE
     ) var quoteData: QuoteRequestData
 ) {
     companion object
@@ -82,6 +84,8 @@ enum class ProductSubType {
 }
 
 enum class ProductType {
-    HOME,
-    HOUSE
+    SWEDISH_APARTMENT,
+    SWEDISH_HOUSE,
+    HOME, // Deprecated use SWEDISH_APARTMENT
+    HOUSE // Deprecated use SWEDISH_HOUSE
 }

--- a/src/test/kotlin/com/hedvig/rapio/quotes/util/QuoteData.kt
+++ b/src/test/kotlin/com/hedvig/rapio/quotes/util/QuoteData.kt
@@ -9,6 +9,21 @@ import java.util.UUID
 object QuoteData {
     val createApartmentRequestJson = """
         {"requestId":"adads",
+         "productType": "SWEDISH_APARTMENT",
+         "quoteData": { 
+            "personalNumber": "191212121212",
+            "street": "testgatan",
+            "zipCode": "12345",
+            "city": "Stockholm",
+            "livingSpace": 42,
+            "householdSize": 2,
+            "productSubType": "RENT"
+         }
+        }
+    """.trimIndent()
+
+    val createDeprecatedApartmentRequestJson = """
+        {"requestId":"adads",
          "productType": "HOME",
          "quoteData": { 
             "personalNumber": "191212121212",
@@ -53,6 +68,28 @@ object QuoteData {
     """.trimIndent()
 
     val createHouseRequestJson = """
+        {
+            "requestId": "1231a",
+            "productType": "SWEDISH_HOUSE",
+            "quoteData": {
+                "street": "harry",
+                "zipCode": "11216",
+                "city": "stockholm",
+                "livingSpace": "240",
+                "personalNumber": "191212121212",
+                "householdSize": "4",
+                "ancilliaryArea": "123",
+                "yearOfConstruction": "1976",
+                "numberOfBathrooms": "2",
+                "extraBuildings": [
+                ],
+                "isSubleted": "false",
+                "floor": "2"
+            }
+        }
+    """.trimIndent()
+
+    val createDeprecatedHouseRequestJson = """
         {
             "requestId": "1231a",
             "productType": "HOUSE",

--- a/src/test/kotlin/com/hedvig/rapio/quotes/web/QuotesControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/quotes/web/QuotesControllerTest.kt
@@ -5,6 +5,8 @@ import com.hedvig.rapio.quotes.QuoteService
 import com.hedvig.rapio.quotes.QuotesController
 import com.hedvig.rapio.quotes.util.QuoteData
 import com.hedvig.rapio.quotes.util.QuoteData.createApartmentRequestJson
+import com.hedvig.rapio.quotes.util.QuoteData.createDeprecatedApartmentRequestJson
+import com.hedvig.rapio.quotes.util.QuoteData.createDeprecatedHouseRequestJson
 import com.hedvig.rapio.quotes.util.QuoteData.createStudentRentApartmentRequestJson
 import com.hedvig.rapio.quotes.util.QuoteData.createStudentBrfApartmentRequestJson
 import com.hedvig.rapio.quotes.util.QuoteData.createHouseRequestJson
@@ -43,6 +45,25 @@ internal class QuotesControllerTest {
     val request = post("/v1/quotes")
       .with(user("compricer"))
       .content(createApartmentRequestJson)
+      .contentType(MediaType.APPLICATION_JSON)
+      .accept(MediaType.APPLICATION_JSON)
+
+    val result = mockMvc.perform(request)
+
+    result
+      .andExpect(status().is2xxSuccessful)
+      .andExpect(jsonPath("$.quoteId", Matchers.any(String::class.java)))
+  }
+
+  @Test
+  @WithMockUser("COMPRICER")
+  fun create_deprecated_apartment_quote() {
+
+    every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+
+    val request = post("/v1/quotes")
+      .with(user("compricer"))
+      .content(createDeprecatedApartmentRequestJson)
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
 
@@ -100,6 +121,25 @@ internal class QuotesControllerTest {
     val request = post("/v1/quotes")
       .with(user("compricer"))
       .content(createHouseRequestJson)
+      .contentType(MediaType.APPLICATION_JSON)
+      .accept(MediaType.APPLICATION_JSON)
+
+    val result = mockMvc.perform(request)
+
+    result
+      .andExpect(status().is2xxSuccessful)
+      .andExpect(jsonPath("$.quoteId", Matchers.any(String::class.java)))
+  }
+
+  @Test
+  @WithMockUser("COMPRICER")
+  fun create_deprecated_house_quote() {
+
+    every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+
+    val request = post("/v1/quotes")
+      .with(user("compricer"))
+      .content(createDeprecatedHouseRequestJson)
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
 


### PR DESCRIPTION
## What?
Added support for `SWEDISH_HOUSE` and `SWEDISH_APARTMENT` replacing
the deprecated `HOUSE` and `APARTMENT`.

## Why?
To align it with other country specific naming...

## Optional checklist
- [x] Codescouted
- [x] Unit tests written
- [x] Tested locally
