### PR TITLE
Fix for getting the country specific payment link url correctly depen…

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/externalservices/apigateway/ApiGateway.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/apigateway/ApiGateway.kt
@@ -13,11 +13,19 @@ class ApiGateway(
   @Value("\${hedvig.api-gateway.token}") private val token: String
 ) {
 
-  fun setupPaymentLink(memberId: String): String? {
+  fun setupPaymentLink(memberId: String, market: String): String? {
     return try {
+      val countryCode = when (market) {
+        "SWEDEN" -> CountryCode.SE
+        "NORWAY" -> CountryCode.NO
+        "DENMARK" -> CountryCode.DK
+        else ->
+          throw RuntimeException("Unknown market: $market")
+      }
+
       val response = apiGatewayClient.setupPaymentLink(
         token,
-        CreateSetupPaymentLinkRequestDto(memberId = memberId, countryCode = CountryCode.SE)
+        CreateSetupPaymentLinkRequestDto(memberId, countryCode)
       )
       response.body!!.url
     } catch (e: Exception) {

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
@@ -18,7 +18,7 @@ import java.time.ZoneId
 class FakeUnderwriter : Underwriter {
 
     override fun signQuote(id: String, email: String, startsAt: LocalDate, firstName: String, lastName: String, ssn: String?): Either<ErrorResponse, SignedQuoteResponseDto> {
-        return Right(SignedQuoteResponseDto(id, "1234", Instant.now()))
+        return Right(SignedQuoteResponseDto(id, "1234", Instant.now(), "SEK"))
     }
 
     override fun createQuote(data: IncompleteQuoteDTO): Either<ErrorResponse, CompleteQuoteReference> {

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/SignQuoteResponseDto.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/SignQuoteResponseDto.kt
@@ -5,5 +5,6 @@ import java.time.Instant
 data class SignedQuoteResponseDto(
         val id: String,
         val memberId: String,
-        val signedAt: Instant
+        val signedAt: Instant,
+        val market: String
 )

--- a/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
@@ -123,7 +123,7 @@ class QuoteServiceImpl(
 
     return when (response) {
       is Either.Right -> {
-        val completionUrlMaybe: String? = apiGateway.setupPaymentLink(response.b.memberId)
+        val completionUrlMaybe: String? = apiGateway.setupPaymentLink(response.b.memberId, response.b.market)
 
         Either.Right(
           SignResponseDTO(

--- a/src/test/kotlin/com/hedvig/rapio/quotes/web/NorwayIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/quotes/web/NorwayIntegrationTest.kt
@@ -197,9 +197,12 @@ class NorwayIntegrationTest {
             SignedQuoteResponseDto(
                 id = uwProductId,
                 memberId = "12345",
-                signedAt = uwSignedAt
+                signedAt = uwSignedAt,
+                market = "NORWAY"
             )
         )
+        val agSetupPaymentLinkRequest1 = slot<String>()
+        val agSetupPaymentLinkRequest2 = slot<String>()
 
         every { concreteUnderwriter.signQuote(
             capture(uwSignRequestId),
@@ -209,6 +212,11 @@ class NorwayIntegrationTest {
             capture(uwSignRequestLastName),
             capture(uwSignRequestSsn)
         ) } returns uwSignResponse
+
+        every { apiGateway.setupPaymentLink(
+            capture(agSetupPaymentLinkRequest1),
+            capture(agSetupPaymentLinkRequest2)
+        ) } returns "payment-link"
 
         val requestData = """
             {
@@ -237,7 +245,7 @@ class NorwayIntegrationTest {
             .andExpect(jsonPath("$.quoteId", equalTo(uwProductId)))
             .andExpect(jsonPath("$.productId", equalTo(uwProductId)))
             .andExpect(jsonPath("$.signedAt", equalTo(uwSignedAt.epochSecond.toInt())))
-            .andExpect(jsonPath("$.completionUrl", equalTo("")))
+            .andExpect(jsonPath("$.completionUrl", equalTo("payment-link")))
 
         assertThat(uwSignRequestId.captured).isEqualTo(uwQuoteId)
         assertThat(uwSignRequestFirstName.captured).isEqualTo("Apan")
@@ -245,6 +253,8 @@ class NorwayIntegrationTest {
         assertThat(uwSignRequestEmail.captured).isEqualTo("apan@apansson.se")
         assertThat(uwSignRequestSsn.captured).isEqualTo("121212012345")
         assertThat(uwSignRequestStartsAt.captured).isEqualTo("${LocalDate.now()}")
-    }
 
+        assertThat(agSetupPaymentLinkRequest1.captured).isEqualTo("12345")
+        assertThat(agSetupPaymentLinkRequest2.captured).isEqualTo("NORWAY")
+    }
 }


### PR DESCRIPTION
Fix for getting the country specific payment link url correctly depending on insurance type.

## Optional checklist
- [ ] Boyscouted
- [x] Unit tests written
- [x] Tested locally

