### PR TITLE
Fix allowing empty `requestId` when creating quotes.

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/QuoteRequestDTO.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/QuoteRequestDTO.kt
@@ -9,7 +9,7 @@ import javax.validation.constraints.*
 
 @optics
 data class QuoteRequestDTO(
-    @get:NotBlank val requestId: String,
+    val requestId: String,
     @get:Valid val productType: ProductType,
     @get:Valid
     @set:JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "productType")

--- a/src/test/kotlin/com/hedvig/rapio/quotes/web/QuotesControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/quotes/web/QuotesControllerTest.kt
@@ -175,6 +175,27 @@ internal class QuotesControllerTest {
 
   @Test
   @WithMockUser("COMPRICER")
+  fun validateBlankRequestIdWorks() {
+
+    every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+
+    val requestJson = createHouseRequestJson.replace("1231a", "")
+
+    val request = post("/v1/quotes")
+      .with(user("compricer"))
+      .content(requestJson)
+      .contentType(MediaType.APPLICATION_JSON)
+      .accept(MediaType.APPLICATION_JSON)
+
+    val result = mockMvc.perform(request)
+
+    result
+      .andExpect(status().is2xxSuccessful)
+      .andExpect(jsonPath("$.quoteId", Matchers.any(String::class.java)))
+  }
+
+  @Test
+  @WithMockUser("COMPRICER")
   fun create_deprecated_house_quote() {
 
     every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))


### PR DESCRIPTION
# Jira Issue: [HVG-979] 

## What?
Fix allowing empty `requestId` when creating quotes.

## Why?
COMPRISER cannot create quotes since they use empty string as `requestId`.

## Optional checklist
- [ ] Boyscouted
- [x] Unit tests written
- [x] Tested locally



[HVG-979]: https://hedvig.atlassian.net/browse/HVG-979