### PR TITLE
Migrate Rapio to use new (not deprecated) sign endpoint in underwriter.

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
@@ -16,7 +16,7 @@ interface UnderwriterClient {
     @RequestMapping(value = ["/_/v1/quotes/bundle"], method = [RequestMethod.POST])
     fun quoteBundle(@RequestBody body: QuoteBundleRequestDto) : ResponseEntity<QuoteBundleResponseDto>
 
-    @RequestMapping(value = ["/_/v1/quotes/{quoteId}/sign"], method = [RequestMethod.POST])
+    @RequestMapping(value = ["/_/v1/quotes/{quoteId}/signFromRapio"], method = [RequestMethod.POST])
     fun signQuote(@PathVariable("quoteId") quoteId: String, @RequestBody body:SignQuoteRequest) : ResponseEntity<SignedQuoteResponseDto>
 
     @RequestMapping(value = ["/_/v1/quotes/bundle/sign"], method = [RequestMethod.POST])


### PR DESCRIPTION
## What?
Migrate Rapio to use new (not deprecated) sign endpoint in underwriter.

Old sign endpoint for Rapio in Underwriter was renamed to match naming of other signing endpoints. 

## Why?
- 

## Optional checklist
- [ ] Boyscouted
- [ ] Unit tests written
- [x] Tested locally

