### PR TITLE
Kill insurance info role since it will no longer be used

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/apikeys/Partner.kt
+++ b/src/main/kotlin/com/hedvig/rapio/apikeys/Partner.kt
@@ -8,6 +8,5 @@ enum class Partner(val role: Roles) {
     KEYSOLUTIONS(role = Roles.COMPARISON),
     SPIFF(role = Roles.COMPARISON),
     TJENSTETORGET(role = Roles.COMPARISON),
-    AVY(role = Roles.INSURANCE_INFO),
-    AVY_DISTRIBUTOR(role = Roles.DISTRIBUTION),
+    AVY(role = Roles.DISTRIBUTION)
 }

--- a/src/main/kotlin/com/hedvig/rapio/apikeys/Roles.kt
+++ b/src/main/kotlin/com/hedvig/rapio/apikeys/Roles.kt
@@ -2,6 +2,5 @@ package com.hedvig.rapio.apikeys
 
 enum class Roles {
     COMPARISON,
-    INSURANCE_INFO,
     DISTRIBUTION
 }

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestMethod
 
 @FeignClient(name = "underwriterclient", url = "\${hedvig.underwriter.url:underwriter}")
 interface UnderwriterClient {
-
     @PostMapping("/_/v1/quotes")
     fun createQuote(@RequestBody body: IncompleteQuoteDTO): ResponseEntity<CompleteQuoteResponse>
 

--- a/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
@@ -20,7 +20,7 @@ class InsuranceInfoController(
     val externalMemberService: ExternalMemberService
 ) {
     @GetMapping("/{memberId}")
-    @Secured("ROLE_INSURANCE_INFO", "ROLE_DISTRIBUTION")
+    @Secured("ROLE_DISTRIBUTION")
     @LogCall
     fun getInsuranceInfo(
         @PathVariable memberId: String

--- a/src/test/kotlin/com/hedvig/rapio/ApiKeysTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/ApiKeysTest.kt
@@ -32,8 +32,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @TestPropertySource(
     properties = [
         "hedvig.rapio.apikeys.mrInsplanetUser=INSPLANET",
-        "hedvig.rapio.apikeys.mrAvyUser=AVY",
-        "hedvig.rapio.apikeys.mrAvyDistributorUser=AVY_DISTRIBUTOR"
+        "hedvig.rapio.apikeys.mrAvyUser=AVY"
     ]
 )
 class ApiKeysTest {
@@ -79,21 +78,6 @@ class ApiKeysTest {
     }
 
     @Test
-    fun `fail to access v1 quotes if the role is INSURANCE_INFO`() {
-        every { quoteService.createQuote(any(), any()) } returns Right(quoteResponse)
-
-        mvc
-            .perform(
-                post("/v1/quotes")
-                    .with(httpBasic("mrAvyUser", ""))
-                    .content(createApartmentRequestJson)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isForbidden)
-    }
-
-    @Test
     fun `succeed to access v1 quotes if the role is ROLE_COMPARISON`() {
 
         every { quoteService.createQuote(any(), any()) } returns Right(quoteResponse)
@@ -117,27 +101,12 @@ class ApiKeysTest {
         mvc
             .perform(
                 post("/v1/quotes")
-                    .with(httpBasic("mrAvyDistributorUser", ""))
+                    .with(httpBasic("mrAvyUser", ""))
                     .content(createApartmentRequestJson)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().is2xxSuccessful)
-    }
-
-    @Test
-    fun `fail to access signing quotes if the role is ROLE_INSURANCE_INFO`() {
-        every { quoteService.signQuote(any(), any(), any()) } returns Right(makeSignResponse())
-
-        mvc
-            .perform(
-                post("/v1/quotes/BA483B2A-2549-4C88-9311-F7394BB34D16/sign")
-                    .with(httpBasic("mrAvyUser", ""))
-                    .content(signRequestJson)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isForbidden)
     }
 
     @Test
@@ -162,7 +131,7 @@ class ApiKeysTest {
         mvc
             .perform(
                 post("/v1/quotes/BA483B2A-2549-4C88-9311-F7394BB34D16/sign")
-                    .with(httpBasic("mrAvyDistributorUser", ""))
+                    .with(httpBasic("mrAvyUser", ""))
                     .content(signRequestJson)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
@@ -184,19 +153,6 @@ class ApiKeysTest {
     }
 
     @Test
-    fun `succeed to access insurance info end-point with the role ROLE_INSURANCE_INFO`() {
-
-        every { insuranceInfoService.getInsuranceInfo(any()) } returns null
-
-        mvc
-            .perform(
-                get("/v1/members/12345")
-                    .with(httpBasic("mrAvyUser", ""))
-            )
-            .andExpect(status().isNotFound)
-    }
-
-    @Test
     fun `succeed to access insurance info end-point with the role ROLE_DISTRIBUTION`() {
 
         every { insuranceInfoService.getInsuranceInfo(any()) } returns null
@@ -204,7 +160,7 @@ class ApiKeysTest {
         mvc
             .perform(
                 get("/v1/members/12345")
-                    .with(httpBasic("mrAvyDistributorUser", ""))
+                    .with(httpBasic("mrAvyUser", ""))
             )
             .andExpect(status().isNotFound)
     }
@@ -217,21 +173,8 @@ class ApiKeysTest {
         mvc
             .perform(
                 get("/v1/members/996195e5-4330-4be9-87a9-a2ae8ce60311/extended")
-                    .with(httpBasic("mrAvyDistributorUser", ""))
-            )
-            .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `fail to access extended insurance info end-point with the role ROLE_INSURANCE_INFO`() {
-
-        every { insuranceInfoService.getInsuranceInfo(any()) } returns null
-
-        mvc
-            .perform(
-                get("/v1/members/996195e5-4330-4be9-87a9-a2ae8ce60311/extended")
                     .with(httpBasic("mrAvyUser", ""))
             )
-            .andExpect(status().isForbidden)
+            .andExpect(status().isNotFound)
     }
 }

--- a/src/test/kotlin/com/hedvig/rapio/external/ExternalMemberServiceTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/external/ExternalMemberServiceTest.kt
@@ -25,7 +25,7 @@ internal class ExternalMemberServiceTest {
 
     @Test
     fun `get memberId by externalMemberId if exists`() {
-        val externalMember = ExternalMember(EXTERNAL_MEMBER_ID, MEMBER_ID, Partner.AVY_DISTRIBUTOR)
+        val externalMember = ExternalMember(EXTERNAL_MEMBER_ID, MEMBER_ID, Partner.AVY)
         repository.saveAndFlush(externalMember)
 
         val memberId = externalMemberServiceToTest.getMemberIdByExternalMemberId(EXTERNAL_MEMBER_ID)

--- a/src/test/kotlin/com/hedvig/rapio/external/ExternalMemberTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/external/ExternalMemberTest.kt
@@ -18,7 +18,7 @@ internal class ExternalMemberTest {
 
     @Test
     fun `can create and find an external member`() {
-        val externalMember = ExternalMember(EXTERNAL_MEMBER_ID, MEMBER_ID, Partner.AVY_DISTRIBUTOR)
+        val externalMember = ExternalMember(EXTERNAL_MEMBER_ID, MEMBER_ID, Partner.AVY)
         val before = Instant.now()
         repository.saveAndFlush(externalMember)
         val after = Instant.now()
@@ -27,17 +27,17 @@ internal class ExternalMemberTest {
         assertThat(result).isNotNull()
         assertThat(result.id).isEqualTo(EXTERNAL_MEMBER_ID)
         assertThat(result.memberId).isEqualTo(MEMBER_ID)
-        assertThat(result.partner).isEqualTo(Partner.AVY_DISTRIBUTOR)
+        assertThat(result.partner).isEqualTo(Partner.AVY)
         assertThat(before).isBefore(result.createdAt)
         assertThat(after).isAfter(result.createdAt)
     }
 
     @Test
     fun `cannot create multiple external members with the same member id`() {
-        val externalMember = ExternalMember(EXTERNAL_MEMBER_ID, MEMBER_ID, Partner.AVY_DISTRIBUTOR)
+        val externalMember = ExternalMember(EXTERNAL_MEMBER_ID, MEMBER_ID, Partner.AVY)
         repository.saveAndFlush(externalMember)
 
-        val externalMemberWithSameMemberId = ExternalMember(UUID.randomUUID(), MEMBER_ID, Partner.AVY_DISTRIBUTOR)
+        val externalMemberWithSameMemberId = ExternalMember(UUID.randomUUID(), MEMBER_ID, Partner.AVY)
         repository.save(externalMemberWithSameMemberId)
     }
 }


### PR DESCRIPTION
# Jira Issue: [] 

## What?
- Get rid of INSURANCE_INFO role

## Why?
- The only consumer is Avy and they'll do more stuff so why not just get rid of it, it's just confuses thing to have an extra role that is not used by anyone

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

