### PR TITLE
Add external member conversion endpoint

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/external/ExternalMemberRepository.kt
+++ b/src/main/kotlin/com/hedvig/rapio/external/ExternalMemberRepository.kt
@@ -3,4 +3,4 @@ package com.hedvig.rapio.external
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface ExternalMemberRepository: JpaRepository<ExternalMember, UUID>
+interface ExternalMemberRepository : JpaRepository<ExternalMember, UUID>

--- a/src/main/kotlin/com/hedvig/rapio/external/ExternalMemberService.kt
+++ b/src/main/kotlin/com/hedvig/rapio/external/ExternalMemberService.kt
@@ -1,5 +1,6 @@
 package com.hedvig.rapio.external
 
+import com.hedvig.rapio.apikeys.Partner
 import mu.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -15,6 +16,16 @@ class ExternalMemberService(
             logger.info { "Unable to find memberId via externalMemberId (externalMemberId=$externalMemberId)" }
         }
         return memberId
+    }
+
+    fun createExternalMember(memberId: String, partner: Partner): ExternalMember {
+        return repository.save(
+            ExternalMember(
+                id = UUID.randomUUID(),
+                memberId = memberId,
+                partner = partner
+            )
+        )
     }
 
     companion object {

--- a/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
@@ -21,12 +21,18 @@ class InsuranceInfoController(
     val insuranceInfoService: InsuranceInfoService,
     val externalMemberService: ExternalMemberService
 ) {
-    @GetMapping("/{memberId}")
+    @GetMapping("/{externalMemberId}")
     @Secured("ROLE_DISTRIBUTION")
     @LogCall
     fun getInsuranceInfo(
-        @PathVariable memberId: String
+        @PathVariable externalMemberId: String
     ): ResponseEntity<InsuranceInfo> {
+        val memberId = try {
+            externalMemberService.getMemberIdByExternalMemberId(UUID.fromString(externalMemberId))
+                ?: return ResponseEntity.notFound().build()
+        } catch (exception: IllegalArgumentException) {
+            externalMemberId
+        }
         return when (val insuranceInfo = insuranceInfoService.getInsuranceInfo(memberId)) {
             null -> ResponseEntity.notFound().build()
             else -> ResponseEntity.ok(insuranceInfo)

--- a/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
@@ -5,9 +5,14 @@ import com.hedvig.rapio.external.ExternalMemberService
 import com.hedvig.rapio.insuranceinfo.dto.DirectDebitLinkResponse
 import com.hedvig.rapio.insuranceinfo.dto.ExtendedInsuranceInfo
 import com.hedvig.rapio.insuranceinfo.dto.InsuranceInfo
+import com.hedvig.rapio.util.getCurrentlyAuthenticatedPartner
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.annotation.Secured
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
@@ -48,7 +53,9 @@ class InsuranceInfoController(
     fun createExternalMember(
         @PathVariable memberId: String
     ): ResponseEntity<UUID> {
-        return ResponseEntity.ok(UUID.randomUUID())
+        val partner = getCurrentlyAuthenticatedPartner()
+        val externalMember = externalMemberService.createExternalMember(memberId, partner)
+        return ResponseEntity.ok(externalMember.id)
     }
 
     @GetMapping("/{externalMemberId}/direct-debit/url")

--- a/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
@@ -7,10 +7,7 @@ import com.hedvig.rapio.insuranceinfo.dto.ExtendedInsuranceInfo
 import com.hedvig.rapio.insuranceinfo.dto.InsuranceInfo
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.annotation.Secured
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.util.UUID
 
 @RestController
@@ -43,6 +40,15 @@ class InsuranceInfoController(
             null -> ResponseEntity.notFound().build()
             else -> ResponseEntity.ok(insuranceInfo)
         }
+    }
+
+    @PostMapping("/{memberId}/to-external-member-id")
+    @Secured("ROLE_DISTRIBUTION")
+    @LogCall
+    fun createExternalMember(
+        @PathVariable memberId: String
+    ): ResponseEntity<UUID> {
+        return ResponseEntity.ok(UUID.randomUUID())
     }
 
     @GetMapping("/{externalMemberId}/direct-debit/url")

--- a/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoController.kt
@@ -54,8 +54,14 @@ class InsuranceInfoController(
         @PathVariable memberId: String
     ): ResponseEntity<UUID> {
         val partner = getCurrentlyAuthenticatedPartner()
-        val externalMember = externalMemberService.createExternalMember(memberId, partner)
-        return ResponseEntity.ok(externalMember.id)
+        val isValidMember = insuranceInfoService.getInsuranceInfo(memberId) != null
+
+        return if (isValidMember) {
+            val externalMember = externalMemberService.createExternalMember(memberId, partner)
+            ResponseEntity.ok(externalMember.id)
+        } else {
+            ResponseEntity.notFound().build()
+        }
     }
 
     @GetMapping("/{externalMemberId}/direct-debit/url")

--- a/src/test/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoControllerTest.kt
@@ -51,7 +51,21 @@ internal class InsuranceInfoControllerTest {
         assertThat(trimmedContent).isEqualTo(EXTERNAL_MEMBER_ID.toString())
     }
 
+    @Test
+    @WithMockUser("AVY")
+    fun `member id that is not connected to a contract should not be converted`() {
+        every { insuranceInfoService.getInsuranceInfo(any()) } returns null
+
+        val request = post("/v1/members/123456/to-external-member-id")
+            .with(user("AVY"))
+
+        val result = mockMvc.perform(request)
+
+        result.andExpect(status().isNotFound)
+    }
+
+
     // 1. Can convert a member id to a external member id ✅
-    // 2. Should not convert a member id that does not have a contract (insurance)
+    // 2. Should not convert a member id that does not have a contract (insurance) ✅
     // 3. Cannot convert a member id that has already been converted
 }

--- a/src/test/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoControllerTest.kt
@@ -1,0 +1,44 @@
+package com.hedvig.rapio.insuranceinfo
+
+import com.hedvig.rapio.external.ExternalMemberService
+import com.ninjasquad.springmockk.MockkBean
+import org.hamcrest.Matchers
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.*
+
+@WebMvcTest(controllers = [InsuranceInfoController::class], secure = false)
+internal class InsuranceInfoControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    lateinit var insuranceInfoService: InsuranceInfoService
+
+    @MockkBean
+    lateinit var externalMemberService: ExternalMemberService
+
+    @Test
+    @WithMockUser("AVY")
+    fun create_external_member() {
+        val request = post("/v1/members/123456/to-external-member-id")
+            .with(user("AVY"))
+
+        val result = mockMvc.perform(request)
+
+        result.andExpect(status().is2xxSuccessful)
+    }
+
+}

--- a/src/test/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/insuranceinfo/InsuranceInfoControllerTest.kt
@@ -3,9 +3,12 @@ package com.hedvig.rapio.insuranceinfo
 import com.hedvig.rapio.apikeys.Partner
 import com.hedvig.rapio.external.ExternalMember
 import com.hedvig.rapio.external.ExternalMemberService
+import com.hedvig.rapio.externalservices.productPricing.InsuranceStatus
+import com.hedvig.rapio.insuranceinfo.dto.InsuranceInfo
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.assertj.core.api.Assertions.assertThat
+import org.javamoney.moneta.Money
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -14,6 +17,8 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.time.LocalDate
 import java.util.UUID
 
 @WebMvcTest(controllers = [InsuranceInfoController::class], secure = false)
@@ -36,6 +41,13 @@ internal class InsuranceInfoControllerTest {
             id = EXTERNAL_MEMBER_ID,
             memberId = "123456",
             partner = Partner.AVY
+        )
+        every { insuranceInfoService.getInsuranceInfo(memberId = "123456") } returns InsuranceInfo(
+            memberId = "123456",
+            insuranceStatus = InsuranceStatus.ACTIVE,
+            insurancePremium = Money.of(BigDecimal.TEN, "SEK"),
+            inceptionDate = LocalDate.now(),
+            paymentConnected = true
         )
         val request = post("/v1/members/123456/to-external-member-id")
             .with(user("AVY"))
@@ -63,9 +75,4 @@ internal class InsuranceInfoControllerTest {
 
         result.andExpect(status().isNotFound)
     }
-
-
-    // 1. Can convert a member id to a external member id ✅
-    // 2. Should not convert a member id that does not have a contract (insurance) ✅
-    // 3. Cannot convert a member id that has already been converted
 }


### PR DESCRIPTION
# Jira Issue: [MX-134] 

## What?
- Add endpoint to convert member ids to external member ids
- Allow old insurance info endpoint to handle external member id as well

## Why?
- So that Avy can repair their old member ids to use UUID format instead

## Optional checklist
- [ ] Codescouted
- [x] Unit tests written
- [ ] Tested locally



[MX-134]: https://hedvig.atlassian.net/browse/MX-134