### PR TITLE
Let distributors provide current insurer for switchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To manually test rAPIo locally:
 
 - Start `RapioApplication` with:
     - Environment variables: POSTGRES_USERNAME=\<user\>;POSTGRES_PASSWORD=\<pass\>
-    - Activ profiles: development, noauth, runtime, fakes, staging
+    - Active profiles: development, noauth, runtime, fakes, staging
   
 - Create and sign a Swedish Apartment quote: 
   ```bash

--- a/src/main/kotlin/com/hedvig/rapio/exceptionhandler/RestExceptionHandler.kt
+++ b/src/main/kotlin/com/hedvig/rapio/exceptionhandler/RestExceptionHandler.kt
@@ -10,9 +10,11 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.context.request.WebRequest
+import org.springframework.web.multipart.support.MissingServletRequestPartException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 
 @ControllerAdvice
@@ -66,6 +68,15 @@ class RestExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(AccessDeniedException::class)
     fun handle(e: AccessDeniedException): ResponseEntity<ExternalErrorResponseDTO> {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ExternalErrorResponseDTO(e.message ?: ""))
+    }
+
+    override fun handleMissingServletRequestParameter(
+        e: MissingServletRequestParameterException,
+        headers: HttpHeaders,
+        status: HttpStatus,
+        request: WebRequest
+    ): ResponseEntity<Any> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExternalErrorResponseDTO(e.message))
     }
 
     @ExceptionHandler

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/ConcreteUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/ConcreteUnderwriter.kt
@@ -111,13 +111,13 @@ class ConcreteUnderwriter(
         try {
             val response = client.signQuoteBundle(
                 SignQuoteBundleRequest(
-                    ids,
-                    SignQuoteBundleRequest.Name(firstName, lastName),
-                    ssn,
-                    startsAt,
-                    email,
-                    price,
-                    currency
+                    quoteIds = ids,
+                    name = SignQuoteBundleRequest.Name(firstName, lastName),
+                    ssn = ssn,
+                    startDate = startsAt,
+                    email = email,
+                    price = price,
+                    currency = currency
                 )
             )
             return Either.right(response.body!!)

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/ConcreteUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/ConcreteUnderwriter.kt
@@ -71,12 +71,16 @@ class ConcreteUnderwriter(
         id: String,
         email: String,
         startsAt: LocalDate?,
+        insuranceCompany: String?,
         firstName: String,
         lastName: String,
         ssn: String?
     ): Either<ErrorResponse, SignedQuoteResponseDto> {
         try {
-            val response = this.client.signQuote(id, SignQuoteRequest(Name(firstName, lastName), ssn, startsAt, email))
+            val response = this.client.signQuote(
+                id,
+                SignQuoteRequest(Name(firstName, lastName), ssn, startsAt, insuranceCompany, email)
+            )
             return Either.right(response.body!!)
         } catch (ex: FeignException) {
             logger.warn { "Failed to sign quote calling Underwriter: $ex" }

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/ConcreteUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/ConcreteUnderwriter.kt
@@ -66,7 +66,7 @@ class ConcreteUnderwriter(
         }
     }
 
-    override fun signQuote(id: String, email: String, startsAt: LocalDate, firstName: String, lastName: String, ssn: String?): Either<ErrorResponse, SignedQuoteResponseDto> {
+    override fun signQuote(id: String, email: String, startsAt: LocalDate?, firstName: String, lastName: String, ssn: String?): Either<ErrorResponse, SignedQuoteResponseDto> {
         try {
             val response = this.client.signQuote(id, SignQuoteRequest(Name(firstName, lastName), ssn, startsAt, email))
             return Either.right(response.body!!)

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/ConcreteUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/ConcreteUnderwriter.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.hedvig.rapio.externalservices.underwriter.transport.*
 import com.hedvig.rapio.externalservices.underwriter.transport.ErrorResponse
+import com.neovisionaries.i18n.CountryCode
 import feign.FeignException
 import mu.KotlinLogging
 import org.javamoney.moneta.Money
@@ -66,7 +67,14 @@ class ConcreteUnderwriter(
         }
     }
 
-    override fun signQuote(id: String, email: String, startsAt: LocalDate?, firstName: String, lastName: String, ssn: String?): Either<ErrorResponse, SignedQuoteResponseDto> {
+    override fun signQuote(
+        id: String,
+        email: String,
+        startsAt: LocalDate?,
+        firstName: String,
+        lastName: String,
+        ssn: String?
+    ): Either<ErrorResponse, SignedQuoteResponseDto> {
         try {
             val response = this.client.signQuote(id, SignQuoteRequest(Name(firstName, lastName), ssn, startsAt, email))
             return Either.right(response.body!!)
@@ -97,7 +105,17 @@ class ConcreteUnderwriter(
     ): Either<ErrorResponse, SignedQuoteBundleResponseDto> {
 
         try {
-            val response = client.signQuoteBundle(SignQuoteBundleRequest(ids, SignQuoteBundleRequest.Name(firstName, lastName), ssn, startsAt, email, price, currency))
+            val response = client.signQuoteBundle(
+                SignQuoteBundleRequest(
+                    ids,
+                    SignQuoteBundleRequest.Name(firstName, lastName),
+                    ssn,
+                    startsAt,
+                    email,
+                    price,
+                    currency
+                )
+            )
             return Either.right(response.body!!)
         } catch (ex: FeignException) {
             logger.warn { "Failed to get quote bundle calling Underwriter: $ex" }
@@ -112,5 +130,9 @@ class ConcreteUnderwriter(
 
             throw ex
         }
+    }
+
+    override fun getInsuranceCompanies(countryCode: CountryCode): List<InsuranceCompanyDto> {
+        return client.getInsuranceCompanies(countryCode).body!!
     }
 }

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
@@ -35,7 +35,7 @@ class FakeUnderwriter : Underwriter {
         )
     }
 
-    override fun signQuote(id: String, email: String, startsAt: LocalDate, firstName: String, lastName: String, ssn: String?): Either<ErrorResponse, SignedQuoteResponseDto> {
+    override fun signQuote(id: String, email: String, startsAt: LocalDate?, firstName: String, lastName: String, ssn: String?): Either<ErrorResponse, SignedQuoteResponseDto> {
         return Right(SignedQuoteResponseDto(id, "1234", Instant.now(), "SWEDEN"))
     }
 

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
@@ -37,7 +37,15 @@ class FakeUnderwriter : Underwriter {
         )
     }
 
-    override fun signQuote(id: String, email: String, startsAt: LocalDate?, firstName: String, lastName: String, ssn: String?): Either<ErrorResponse, SignedQuoteResponseDto> {
+    override fun signQuote(
+        id: String,
+        email: String,
+        startsAt: LocalDate?,
+        insuranceCompany: String?,
+        firstName: String,
+        lastName: String,
+        ssn: String?
+    ): Either<ErrorResponse, SignedQuoteResponseDto> {
         return Right(SignedQuoteResponseDto(id, "1234", Instant.now(), "SWEDEN"))
     }
 

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
@@ -4,10 +4,12 @@ import arrow.core.Either
 import arrow.core.Right
 import com.hedvig.rapio.externalservices.underwriter.transport.ErrorResponse
 import com.hedvig.rapio.externalservices.underwriter.transport.IncompleteQuoteDTO
+import com.hedvig.rapio.externalservices.underwriter.transport.InsuranceCompanyDto
 import com.hedvig.rapio.externalservices.underwriter.transport.QuoteBundleRequestDto
 import com.hedvig.rapio.externalservices.underwriter.transport.QuoteBundleResponseDto
 import com.hedvig.rapio.externalservices.underwriter.transport.SignedQuoteBundleResponseDto
 import com.hedvig.rapio.externalservices.underwriter.transport.SignedQuoteResponseDto
+import com.neovisionaries.i18n.CountryCode
 import org.javamoney.moneta.Money
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
@@ -57,4 +59,6 @@ class FakeUnderwriter : Underwriter {
             )
         )
     }
+
+    override fun getInsuranceCompanies(countryCode: CountryCode): List<InsuranceCompanyDto> = emptyList()
 }

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/Underwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/Underwriter.kt
@@ -18,7 +18,7 @@ interface Underwriter {
     fun signQuote(
         id: String,
         email: String,
-        startsAt: LocalDate,
+        startsAt: LocalDate?,
         firstName: String,
         lastName: String,
         ssn: String?

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/Underwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/Underwriter.kt
@@ -21,6 +21,7 @@ interface Underwriter {
         id: String,
         email: String,
         startsAt: LocalDate?,
+        insuranceCompany: String?,
         firstName: String,
         lastName: String,
         ssn: String?

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/Underwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/Underwriter.kt
@@ -3,10 +3,12 @@ package com.hedvig.rapio.externalservices.underwriter
 import arrow.core.Either
 import com.hedvig.rapio.externalservices.underwriter.transport.ErrorResponse
 import com.hedvig.rapio.externalservices.underwriter.transport.IncompleteQuoteDTO
+import com.hedvig.rapio.externalservices.underwriter.transport.InsuranceCompanyDto
 import com.hedvig.rapio.externalservices.underwriter.transport.QuoteBundleRequestDto
 import com.hedvig.rapio.externalservices.underwriter.transport.QuoteBundleResponseDto
 import com.hedvig.rapio.externalservices.underwriter.transport.SignedQuoteBundleResponseDto
 import com.hedvig.rapio.externalservices.underwriter.transport.SignedQuoteResponseDto
+import com.neovisionaries.i18n.CountryCode
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -34,6 +36,10 @@ interface Underwriter {
         price: String?,
         currency: String?
     ): Either<ErrorResponse, SignedQuoteBundleResponseDto>
+
+    fun getInsuranceCompanies(
+        countryCode: CountryCode
+    ): List<InsuranceCompanyDto>
 }
 
 data class CompleteQuoteReference(

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/InsuranceCompanyDto.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/InsuranceCompanyDto.kt
@@ -1,0 +1,7 @@
+package com.hedvig.rapio.externalservices.underwriter.transport
+
+data class InsuranceCompanyDto(
+    val id: String,
+    val displayName: String,
+    val switchable: Boolean
+)

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/SignQuoteRequest.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/SignQuoteRequest.kt
@@ -7,7 +7,7 @@ import java.time.ZoneId
 data class SignQuoteRequest(
     val name: Name?,
     @Masked val ssn: String?,
-    val startDate: LocalDate,
+    val startDate: LocalDate?,
     @Masked val email: String
 )
 

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/SignQuoteRequest.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/SignQuoteRequest.kt
@@ -8,6 +8,7 @@ data class SignQuoteRequest(
     val name: Name?,
     @Masked val ssn: String?,
     val startDate: LocalDate?,
+    val insuranceCompany: String?,
     @Masked val email: String
 )
 

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
@@ -1,7 +1,9 @@
 package com.hedvig.rapio.externalservices.underwriter.transport
 
+import com.neovisionaries.i18n.CountryCode
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -21,4 +23,7 @@ interface UnderwriterClient {
 
     @PostMapping("/_/v1/quotes/bundle/signFromRapio")
     fun signQuoteBundle(@RequestBody body: SignQuoteBundleRequest): ResponseEntity<SignedQuoteBundleResponseDto>
+
+    @GetMapping("/insurance-companies")
+    fun getInsuranceCompanies(countryCode:CountryCode) : ResponseEntity<List<InsuranceCompanyDto>>
 }

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
@@ -26,5 +26,5 @@ interface UnderwriterClient {
     fun signQuoteBundle(@RequestBody body: SignQuoteBundleRequest): ResponseEntity<SignedQuoteBundleResponseDto>
 
     @GetMapping("/insurance-companies")
-    fun getInsuranceCompanies(@RequestParam countryCode:CountryCode) : ResponseEntity<List<InsuranceCompanyDto>>
+    fun getInsuranceCompanies(@RequestParam countryCode: CountryCode) : ResponseEntity<List<InsuranceCompanyDto>>
 }

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/transport/UnderwriterClient.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
 
 @FeignClient(name = "underwriterclient", url = "\${hedvig.underwriter.url:underwriter}")
 interface UnderwriterClient {
@@ -25,5 +26,5 @@ interface UnderwriterClient {
     fun signQuoteBundle(@RequestBody body: SignQuoteBundleRequest): ResponseEntity<SignedQuoteBundleResponseDto>
 
     @GetMapping("/insurance-companies")
-    fun getInsuranceCompanies(countryCode:CountryCode) : ResponseEntity<List<InsuranceCompanyDto>>
+    fun getInsuranceCompanies(@RequestParam countryCode:CountryCode) : ResponseEntity<List<InsuranceCompanyDto>>
 }

--- a/src/main/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesController.kt
@@ -1,0 +1,36 @@
+package com.hedvig.rapio.insurancecompanies
+
+import com.hedvig.libs.logging.calls.LogCall
+import com.hedvig.rapio.externalservices.underwriter.Underwriter
+import com.hedvig.rapio.insurancecompanies.dto.InsuranceCompanyDto
+import com.hedvig.rapio.insurancecompanies.dto.toDto
+import com.neovisionaries.i18n.CountryCode
+import feign.FeignException
+import mu.KotlinLogging
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.annotation.Secured
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = KotlinLogging.logger {}
+
+@RestController
+@RequestMapping("v1/insurance-companies")
+class InsuranceCompaniesController(
+    val underwriter: Underwriter
+) {
+
+    @GetMapping
+    @Secured("ROLE_DISTRIBUTION")
+    @LogCall
+    fun getInsuranceCompanies(@RequestParam countryCode: CountryCode): ResponseEntity<List<InsuranceCompanyDto>> {
+        return try {
+            ResponseEntity.ok(underwriter.getInsuranceCompanies(countryCode).map { it.toDto() })
+        } catch (ex: FeignException) {
+            logger.error(ex) { "Failed to get insurance companies from underwriter for countryCode: $countryCode" }
+            ResponseEntity.status(502).build<List<InsuranceCompanyDto>>()
+        }
+    }
+}

--- a/src/main/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesController.kt
@@ -23,7 +23,7 @@ class InsuranceCompaniesController(
 ) {
 
     @GetMapping
-    @Secured("ROLE_DISTRIBUTION")
+    @Secured("ROLE_DISTRIBUTION", "ROLE_COMPARISON")
     @LogCall
     fun getInsuranceCompanies(@RequestParam countryCode: CountryCode): ResponseEntity<List<InsuranceCompanyDto>> {
         return try {

--- a/src/main/kotlin/com/hedvig/rapio/insurancecompanies/dto/InsuranceCompanyDto.kt
+++ b/src/main/kotlin/com/hedvig/rapio/insurancecompanies/dto/InsuranceCompanyDto.kt
@@ -1,0 +1,11 @@
+package com.hedvig.rapio.insurancecompanies.dto
+
+import com.hedvig.rapio.externalservices.underwriter.transport.InsuranceCompanyDto as UnderwriterInsuranceCompanyDto
+
+data class InsuranceCompanyDto(
+    val id: String,
+    val displayName: String,
+    val switchable: Boolean
+)
+
+fun UnderwriterInsuranceCompanyDto.toDto(): InsuranceCompanyDto = InsuranceCompanyDto(id, displayName, switchable)

--- a/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
@@ -203,12 +203,13 @@ class QuoteServiceImpl(
 
     override fun signQuote(quoteId: UUID, request: SignRequestDTO, isForced: Boolean): Either<String, SignResponseDTO> {
         val response = this.underwriter.signQuote(
-            quoteId.toString(),
-            request.email,
-            request.startsAt?.date,
-            request.firstName,
-            request.lastName,
-            request.personalNumber
+            id = quoteId.toString(),
+            email = request.email,
+            startsAt = request.startsAt?.date,
+            insuranceCompany = request.currentInsuranceCompanyId,
+            firstName = request.firstName,
+            lastName = request.lastName,
+            ssn = request.personalNumber
         )
 
         return response.bimap(

--- a/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
@@ -205,7 +205,7 @@ class QuoteServiceImpl(
         val response = this.underwriter.signQuote(
             quoteId.toString(),
             request.email,
-            request.startsAt.date,
+            request.startsAt?.date,
             request.firstName,
             request.lastName,
             request.personalNumber

--- a/src/main/kotlin/com/hedvig/rapio/quotes/QuotesController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/QuotesController.kt
@@ -109,6 +109,9 @@ class QuotesController @Autowired constructor(
     ): ResponseEntity<out Any> = signQuote(quoteId, request, false)
 
     private fun signQuote(quoteId: UUID, request: SignRequestDTO, isForced: Boolean): ResponseEntity<*> {
+        if (request.startsAt == null && request.currentInsuranceCompanyId == null) {
+            return ResponseEntity.badRequest().body("currentInsuranceCompanyId is required when startsAt is null")
+        }
         return logRequestId(request.requestId) {
 
             val response = quoteService.signQuote(quoteId, request, isForced)

--- a/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/SignRequestDTO.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/SignRequestDTO.kt
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotBlank
 
 data class SignRequestDTO(
     val requestId: String,
-    @get:Valid val startsAt: Date,
+    @get:Valid val startsAt: Date?,
 
     @get:Email @Masked val email: String,
 

--- a/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/SignRequestDTO.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/web/dto/SignRequestDTO.kt
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotBlank
 data class SignRequestDTO(
     val requestId: String,
     @get:Valid val startsAt: Date?,
+    val currentInsuranceCompanyId: String?,
 
     @get:Email @Masked val email: String,
 

--- a/src/test/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesControllerTest.kt
@@ -1,0 +1,90 @@
+package com.hedvig.rapio.insurancecompanies
+
+import com.hedvig.rapio.externalservices.underwriter.Underwriter
+import com.hedvig.rapio.externalservices.underwriter.transport.InsuranceCompanyDto
+import com.neovisionaries.i18n.CountryCode
+import com.ninjasquad.springmockk.MockkBean
+import feign.FeignException
+import feign.Request
+import feign.Response
+import io.mockk.every
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@WebMvcTest(controllers = [InsuranceCompaniesController::class], secure = false)
+internal class InsuranceCompaniesControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    lateinit var underwriter: Underwriter
+
+    @Test
+    @WithMockUser("AVY")
+    fun `returns list of companies when ok upstream response`() {
+        val countryCode = CountryCode.SE
+        val insuranceCompanies = listOf(
+            InsuranceCompanyDto("if", "If", false),
+            InsuranceCompanyDto("trygg-hansa", "Trygg Hansa", true)
+        )
+
+        every { underwriter.getInsuranceCompanies(countryCode) } returns insuranceCompanies
+
+        val result = mockMvc.perform(
+            get("/v1/insurance-companies")
+                .with(user("AVY"))
+                .param("countryCode", "SE")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        result.andExpect(status().is2xxSuccessful)
+            .andExpect(jsonPath("$[0].id", Matchers.`is`("if")))
+    }
+
+    @Test
+    @WithMockUser("AVY")
+    fun `returns 502 when error from underwriter`() {
+        val countryCode = CountryCode.SE
+
+        every { underwriter.getInsuranceCompanies(countryCode) } throws FeignException.errorStatus(
+            "bla",
+            Response.builder().status(500).headers(emptyMap()).reason("Error")
+                .request(Request.create(Request.HttpMethod.GET, "url", emptyMap(), null)).build()
+        )
+
+        val result = mockMvc.perform(
+            get("/v1/insurance-companies")
+                .with(user("AVY"))
+                .param("countryCode", "SE")
+        )
+        result.andExpect(status().`is`(502))
+    }
+
+    @Test
+    @WithMockUser("AVY")
+    fun `invalid countrycode returns 400`() {
+        val countryCode = CountryCode.SE
+
+        every { underwriter.getInsuranceCompanies(countryCode) } throws FeignException.errorStatus(
+            "bla",
+            Response.builder().status(500).headers(emptyMap()).reason("Error")
+                .request(Request.create(Request.HttpMethod.GET, "url", emptyMap(), null)).build()
+        )
+
+        val result = mockMvc.perform(
+            get("/v1/insurance-companies")
+                .with(user("AVY"))
+                .param("countryCode", "Sweden")
+        )
+        result.andExpect(status().`is`(400))
+    }
+}

--- a/src/test/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesControllerTest.kt
@@ -48,6 +48,7 @@ internal class InsuranceCompaniesControllerTest {
 
         result.andExpect(status().is2xxSuccessful)
             .andExpect(jsonPath("$[0].id", Matchers.`is`("if")))
+            .andExpect(jsonPath("$[1].id", Matchers.`is`("trygg-hansa")))
     }
 
     @Test

--- a/src/test/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/insurancecompanies/InsuranceCompaniesControllerTest.kt
@@ -87,5 +87,6 @@ internal class InsuranceCompaniesControllerTest {
                 .param("countryCode", "Sweden")
         )
         result.andExpect(status().`is`(400))
+        result.andExpect(content().string(""))
     }
 }


### PR DESCRIPTION
# Jira Issue: [MX-107] 

## What?
- Make start date optional when signing
- Add field for currentInsuranceCompanyId when signing
- Add endpoint to get insurance companies per country (used to populate the above field)

## Why?
- So that distributors can sign people with a current insurance without knowing the start date.

## Optional checklist
- [x] Codescouted
- [x] Unit tests written
- [x] Tested locally



[MX-107]: https://hedvig.atlassian.net/browse/MX-107