### PR TITLE
MX-181: make sure a personal number is not taken when creating trials

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/externalservices/memberService/MemberService.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/memberService/MemberService.kt
@@ -9,6 +9,7 @@ import com.hedvig.rapio.externalservices.memberService.dto.SimpleSignConnectionD
 import com.hedvig.rapio.externalservices.memberService.dto.UpdateMemberRequest
 import com.hedvig.rapio.externalservices.memberService.model.NewMemberInfo
 import com.hedvig.rapio.externalservices.productPricing.transport.ProductPricingClient
+import com.hedvig.rapio.util.forbidden
 import com.hedvig.rapio.util.internalServerError
 import com.neovisionaries.i18n.CountryCode
 import java.time.LocalDate
@@ -49,6 +50,12 @@ class MemberService(
         fromDate: LocalDate,
         newMemberInfo: NewMemberInfo
     ): Long {
+        val personalNumberIsTaken = memberServiceClient.getIsMember(
+            IsMemberRequest(ssn = newMemberInfo.personalNumber)
+        ).bodyOrNull() ?: throw internalServerError()
+        if (personalNumberIsTaken) {
+            throw forbidden()
+        }
         val memberId = memberServiceClient.createMember(
             CreateMemberRequest(language, partner.toString())
         ).bodyOrNull()?.memberId ?: throw internalServerError()

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/memberService/dto/IsMemberRequest.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/memberService/dto/IsMemberRequest.kt
@@ -3,7 +3,7 @@ package com.hedvig.rapio.externalservices.memberService.dto
 import com.hedvig.libs.logging.masking.Masked
 
 data class IsMemberRequest(
-    val memberId: String?,
-    @Masked val ssn: String?,
-    @Masked val email: String?
+    val memberId: String? = null,
+    @Masked val ssn: String? = null,
+    @Masked val email: String? = null
 )

--- a/src/test/kotlin/com/hedvig/rapio/members/MembersControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/members/MembersControllerTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.test.context.ContextConfiguration
 
@@ -34,6 +35,7 @@ class MembersControllerTest : IntegrationTest() {
     fun `Can create trial insurance`() {
         val memberId = 1337L
 
+        every { memberServiceClient.getIsMember(IsMemberRequest(ssn = "191212121212")) } returns ResponseEntity.ok(false)
         every { memberServiceClient.createMember(any()) } returns ResponseEntity.ok(
             CreateMemberResponse(memberId = memberId)
         )
@@ -68,12 +70,42 @@ class MembersControllerTest : IntegrationTest() {
                 "birthDate" to "1900-01-01"
             ),
             headers = mapOf(
-                "Content-Type" to "Application/json",
                 "Accept-Language" to "en"
             )
         ).assert2xx()
 
         assertThat(result.body<Map<String, Any>>()["memberId"]).isNotNull
+    }
+
+    @Test
+    fun `Cannot create trial insurance if member service says the SSN is taken`() {
+        every { memberServiceClient.getIsMember(IsMemberRequest(ssn = "191212121212")) } returns ResponseEntity.ok(true)
+
+        client.post(
+            uri = "/v1/members/trial",
+            body = mapOf(
+                "personalNumber" to "191212121212",
+                "firstName" to "Testy",
+                "lastName" to "Tester",
+                "email" to "test@example.com",
+                "countryCode" to "SE",
+                "phoneNumber" to "08-8888",
+                "address" to mapOf(
+                    "street" to "testgatan",
+                    "zipCode" to "12345",
+                    "city" to "Stockholm",
+                    "livingSpace" to 40,
+                    "apartmentNo" to "1",
+                    "floor" to 2
+                ),
+                "fromDate" to "2021-04-04",
+                "type" to "SE_APARTMENT_BRF",
+                "birthDate" to "1900-01-01"
+            ),
+            headers = mapOf(
+                "Accept-Language" to "en"
+            )
+        ).assertStatus(HttpStatus.FORBIDDEN)
     }
 
     @Test


### PR DESCRIPTION
# Jira Issue: [MX-181] 

## What?
- Adds validation that a specific personal number (SSN) isn't taken when creating a member through a trial

## Why?
- Since several of our endpoints create members as a side effect of creating something else (trials, signing quotes), we need to add more input validation for whether a specific SSN is already taken.
- In the future, we should build an API where members are not created as a side effect, but rather something that has to be created prior to accessing the other things (signing quotes, creating trials), and then we can have a single point where we validate this constraint. But for now it has to be validated here as well.

## Optional checklist
- [ ] Codescouted
- [x] Unit tests written
- [ ] Tested locally



[MX-181]: https://hedvig.atlassian.net/browse/MX-181