### PR TITLE
Passthrough error messages in the 4xx range

### DIFF
--- a/src/main/kotlin/com/hedvig/rapio/exceptionhandler/RestExceptionHandler.kt
+++ b/src/main/kotlin/com/hedvig/rapio/exceptionhandler/RestExceptionHandler.kt
@@ -2,6 +2,8 @@ package com.hedvig.rapio.exceptionhandler
 
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.hedvig.rapio.comparison.web.dto.ExternalErrorResponseDTO
 import feign.FeignException
 import org.springframework.http.HttpHeaders
@@ -88,9 +90,11 @@ class RestExceptionHandler : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler
     fun handle(e: FeignException): ResponseEntity<Any> {
+        val jsonContent = jacksonObjectMapper().readValue<MutableMap<String, Any>>(e.contentUTF8())
+        jsonContent.remove("path")
         return when {
             e.status() in 400..499 -> {
-                ResponseEntity(e.contentUTF8(), HttpStatus.valueOf(e.status()))
+                ResponseEntity(jsonContent, HttpStatus.valueOf(e.status()))
             }
             else -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
         }

--- a/src/main/kotlin/com/hedvig/rapio/exceptionhandler/RestExceptionHandler.kt
+++ b/src/main/kotlin/com/hedvig/rapio/exceptionhandler/RestExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.hedvig.rapio.exceptionhandler
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.hedvig.rapio.comparison.web.dto.ExternalErrorResponseDTO
+import feign.FeignException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -83,6 +84,16 @@ class RestExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler
     fun handle(e: Exception): ResponseEntity<ExternalErrorResponseDTO> {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ExternalErrorResponseDTO(e.message ?: ""))
+    }
+
+    @ExceptionHandler
+    fun handle(e: FeignException): ResponseEntity<Any> {
+        return when {
+            e.status() in 400..499 -> {
+                ResponseEntity(e.contentUTF8(), HttpStatus.valueOf(e.status()))
+            }
+            else -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
     }
 
     @ExceptionHandler

--- a/src/main/kotlin/com/hedvig/rapio/exceptionhandler/RestExceptionHandler.kt
+++ b/src/main/kotlin/com/hedvig/rapio/exceptionhandler/RestExceptionHandler.kt
@@ -91,25 +91,7 @@ class RestExceptionHandler(
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ExternalErrorResponseDTO(e.message ?: ""))
     }
 
-    @ExceptionHandler(
-        FeignException::class,
-        FeignException.BadRequest::class,
-        FeignException.Unauthorized::class,
-        FeignException.Forbidden::class,
-        FeignException.NotFound::class,
-        FeignException.MethodNotAllowed::class,
-        FeignException.NotAcceptable::class,
-        FeignException.Conflict::class,
-        FeignException.Gone::class,
-        FeignException.UnsupportedMediaType::class,
-        FeignException.TooManyRequests::class,
-        FeignException.UnprocessableEntity::class,
-        FeignException.InternalServerError::class,
-        FeignException.NotImplemented::class,
-        FeignException.BadGateway::class,
-        FeignException.ServiceUnavailable::class,
-        FeignException.GatewayTimeout::class
-    )
+    @ExceptionHandler(FeignException::class)
     fun handle(e: FeignException): ResponseEntity<Any> {
         val content = try {
             val jsonContent = mapper.readValue<MutableMap<String, Any>>(e.contentUTF8())

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/FakeUnderwriter.kt
@@ -21,8 +21,8 @@ import java.util.UUID
 @Component
 class FakeUnderwriter : Underwriter {
 
-    override fun createQuote(data: IncompleteQuoteDTO): Either<ErrorResponse, CompleteQuoteReference> {
-        return Right(CompleteQuoteReference("someId", Money.of(10, "SEK"), Instant.now()))
+    override fun createQuote(data: IncompleteQuoteDTO): CompleteQuoteReference {
+        return CompleteQuoteReference("someId", Money.of(10, "SEK"), Instant.now())
     }
 
     override fun quoteBundle(request: QuoteBundleRequestDto): Either<ErrorResponse, QuoteBundleResponseDto> {

--- a/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/Underwriter.kt
+++ b/src/main/kotlin/com/hedvig/rapio/externalservices/underwriter/Underwriter.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 import javax.money.MonetaryAmount
 
 interface Underwriter {
-    fun createQuote(data: IncompleteQuoteDTO): Either<ErrorResponse, CompleteQuoteReference>
+    fun createQuote(data: IncompleteQuoteDTO): CompleteQuoteReference
     fun quoteBundle(request: QuoteBundleRequestDto): Either<ErrorResponse, QuoteBundleResponseDto>
     fun signQuote(
         id: String,

--- a/src/main/kotlin/com/hedvig/rapio/members/MembersController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/members/MembersController.kt
@@ -9,6 +9,7 @@ import com.hedvig.rapio.insuranceinfo.dto.IsMemberRequest
 import com.hedvig.rapio.insuranceinfo.dto.IsMemberResponse
 import com.hedvig.rapio.members.dto.CreateTrialMemberRequest
 import com.hedvig.rapio.members.dto.CreateTrialMemberResponse
+import com.hedvig.rapio.util.badRequest
 import com.hedvig.rapio.util.getCurrentlyAuthenticatedPartner
 import com.hedvig.rapio.util.unauthorized
 import org.springframework.http.ResponseEntity
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
+import org.springframework.web.client.HttpClientErrorException
 
 @RestController
 @RequestMapping("v1/members")
@@ -38,7 +40,7 @@ class MembersController(
         val trialEndDate = body.fromDate.plusDays(30)
         val today = LocalDate.now()
         require(!trialEndDate.isBefore(today)) {
-            return ResponseEntity.badRequest().build()
+            throw badRequest("Invalid fromDate: must not be more than 30 days ago")
         }
 
         val partner = getCurrentlyAuthenticatedPartner()

--- a/src/main/kotlin/com/hedvig/rapio/quotes/QuoteService.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/QuoteService.kt
@@ -13,7 +13,7 @@ import com.hedvig.rapio.quotes.web.dto.SignResponseDTO
 import java.util.UUID
 
 interface QuoteService {
-    fun createQuote(requestDTO: QuoteRequestDTO, partner: Partner): Either<String, QuoteResponseDTO>
+    fun createQuote(requestDTO: QuoteRequestDTO, partner: Partner): QuoteResponseDTO
     fun bundleQuotes(request: BundleQuotesRequestDTO): Either<String, BundleQuotesResponseDTO>
     fun signQuote(quoteId: UUID, request: SignRequestDTO): Either<String, SignResponseDTO>
     fun signBundle(request: SignBundleRequestDTO): Either<String, SignBundleResponseDTO>

--- a/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/QuoteServiceImpl.kt
@@ -50,7 +50,7 @@ class QuoteServiceImpl(
     val apiGateway: ApiGateway
 ) : QuoteService {
 
-    override fun createQuote(requestDTO: QuoteRequestDTO, partner: Partner): Either<String, QuoteResponseDTO> {
+    override fun createQuote(requestDTO: QuoteRequestDTO, partner: Partner): QuoteResponseDTO {
         val quoteData = requestDTO.quoteData
 
         val requestQuoteData = when (quoteData) {
@@ -176,16 +176,11 @@ class QuoteServiceImpl(
 
         val completeQuote = underwriter.createQuote(request)
 
-        return completeQuote.bimap(
-            { it.errorMessage },
-            {
-                QuoteResponseDTO(
-                    requestDTO.requestId,
-                    it.id,
-                    it.validTo.epochSecond,
-                    it.price
-                )
-            }
+        return QuoteResponseDTO(
+            requestDTO.requestId,
+            completeQuote.id,
+            completeQuote.validTo.epochSecond,
+            completeQuote.price
         )
     }
 
@@ -234,7 +229,13 @@ class QuoteServiceImpl(
                 val completionUrlMaybe: String? = apiGateway.setupPaymentLink(response.memberId, response.market)
                 val partner = getCurrentlyAuthenticatedPartner()
                 val externalMember =
-                    member ?: externalMemberRepository.save(ExternalMember(UUID.randomUUID(), response.memberId, partner))
+                    member ?: externalMemberRepository.save(
+                        ExternalMember(
+                            UUID.randomUUID(),
+                            response.memberId,
+                            partner
+                        )
+                    )
 
                 SignResponseDTO(
                     requestId = request.requestId,
@@ -280,7 +281,13 @@ class QuoteServiceImpl(
                 val completionUrlMaybe: String? = apiGateway.setupPaymentLink(response.memberId, response.market)
                 val partner = getCurrentlyAuthenticatedPartner()
                 val externalMember =
-                    member ?: externalMemberRepository.save(ExternalMember(UUID.randomUUID(), response.memberId, partner))
+                    member ?: externalMemberRepository.save(
+                        ExternalMember(
+                            UUID.randomUUID(),
+                            response.memberId,
+                            partner
+                        )
+                    )
 
                 SignBundleResponseDTO(
                     requestId = request.requestId,

--- a/src/main/kotlin/com/hedvig/rapio/quotes/QuotesController.kt
+++ b/src/main/kotlin/com/hedvig/rapio/quotes/QuotesController.kt
@@ -16,7 +16,6 @@ import com.hedvig.rapio.quotes.web.dto.QuoteRequestDTO
 import com.hedvig.rapio.quotes.web.dto.SignBundleRequestDTO
 import com.hedvig.rapio.quotes.web.dto.SignRequestDTO
 import com.hedvig.rapio.util.SwedishPersonalNumberValidator
-import com.hedvig.rapio.util.notAccepted
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
@@ -69,10 +68,7 @@ class QuotesController @Autowired constructor(
             is DanishAccidentQuoteRequestData -> request
         }
 
-        return@logRequestId quoteService.createQuote(requestData, partner).bimap(
-            { left -> notAccepted(left) },
-            { right -> ok(right) }
-        ).getOrHandle { it }
+        return@logRequestId ok(quoteService.createQuote(requestData, partner))
     }
 
     @PostMapping("/bundle")

--- a/src/main/kotlin/com/hedvig/rapio/util/Errors.kt
+++ b/src/main/kotlin/com/hedvig/rapio/util/Errors.kt
@@ -23,3 +23,10 @@ fun unauthorized(message: String? = null) = HttpServerErrorException(
     message?.toByteArray(Charsets.UTF_8),
     Charsets.UTF_8
 )
+
+fun badRequest(message: String? = null) = HttpServerErrorException(
+    HttpStatus.BAD_REQUEST,
+    HttpStatus.BAD_REQUEST.reasonPhrase,
+    message?.toByteArray(Charsets.UTF_8),
+    Charsets.UTF_8
+)

--- a/src/main/kotlin/com/hedvig/rapio/util/ResponseEntityExtension.kt
+++ b/src/main/kotlin/com/hedvig/rapio/util/ResponseEntityExtension.kt
@@ -1,8 +1,0 @@
-package com.hedvig.rapio.util
-
-import com.hedvig.rapio.comparison.web.dto.ExternalErrorResponseDTO
-import org.springframework.http.ResponseEntity
-
-fun notAccepted(error: String) = ResponseEntity.status(422).body(ExternalErrorResponseDTO(error))
-
-fun badRequest(error: String) = ResponseEntity.badRequest().body(ExternalErrorResponseDTO(error))

--- a/src/test/kotlin/com/hedvig/rapio/ApiKeysTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/ApiKeysTest.kt
@@ -88,7 +88,7 @@ class ApiKeysTest {
     @Test
     fun `succeed to access v1 quotes if the role is ROLE_COMPARISON`() {
 
-        every { quoteService.createQuote(any(), any()) } returns Right(quoteResponse)
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         mvc
             .perform(
@@ -104,7 +104,7 @@ class ApiKeysTest {
     @Test
     fun `succeed to access v1 quotes if the role is ROLE_DISTRIBUTION`() {
 
-        every { quoteService.createQuote(any(), any()) } returns Right(quoteResponse)
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         mvc
             .perform(

--- a/src/test/kotlin/com/hedvig/rapio/helpers/TestHttpClient.kt
+++ b/src/test/kotlin/com/hedvig/rapio/helpers/TestHttpClient.kt
@@ -73,6 +73,10 @@ class TestHttpClient(
             return this
         }
 
+        fun status() : HttpStatus {
+            return entity.statusCode
+        }
+
         inline fun <reified T> body(): T {
             return body(object : TypeReference<T>() {})
         }

--- a/src/test/kotlin/com/hedvig/rapio/quotes/web/QuotesControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/rapio/quotes/web/QuotesControllerTest.kt
@@ -1,6 +1,5 @@
 package com.hedvig.rapio.quotes.web
 
-import arrow.core.Left
 import arrow.core.Right
 import com.hedvig.rapio.quotes.QuoteService
 import com.hedvig.rapio.quotes.QuotesController
@@ -44,7 +43,7 @@ internal class QuotesControllerTest {
     @WithMockUser("COMPRICER")
     fun create_apartment_quote() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val request = post("/v1/quotes")
             .with(user("compricer"))
@@ -63,7 +62,7 @@ internal class QuotesControllerTest {
     @WithMockUser("COMPRICER")
     fun create_deprecated_apartment_quote() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val request = post("/v1/quotes")
             .with(user("compricer"))
@@ -98,29 +97,9 @@ internal class QuotesControllerTest {
 
     @Test
     @WithMockUser("COMPRICER")
-    @Throws
-    fun create_breaching_uw_apartment_quote() {
-
-        every { quoteService.createQuote(any(), any()) } returns (Left("Testing"))
-
-        val request = post("/v1/quotes")
-            .with(user("compricer"))
-            .content(createApartmentRequestJson)
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-
-        val result = mockMvc.perform(request)
-
-        result
-            .andExpect(status().isUnprocessableEntity)
-            .andExpect(jsonPath("$.errorMessage", Matchers.equalTo("Testing")))
-    }
-
-    @Test
-    @WithMockUser("COMPRICER")
     fun create_student_rent_apartment_quote() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val request = post("/v1/quotes")
             .with(user("compricer"))
@@ -139,7 +118,7 @@ internal class QuotesControllerTest {
     @WithMockUser("COMPRICER")
     fun create_student_brf_apartment_quote() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val request = post("/v1/quotes")
             .with(user("compricer"))
@@ -158,7 +137,7 @@ internal class QuotesControllerTest {
     @WithMockUser("COMPRICER")
     fun create_house_quote() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val request = post("/v1/quotes")
             .with(user("compricer"))
@@ -177,7 +156,7 @@ internal class QuotesControllerTest {
     @WithMockUser("COMPRICER")
     fun validateBlankRequestIdWorks() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val requestJson = createHouseRequestJson.replace("1231a", "")
 
@@ -198,7 +177,7 @@ internal class QuotesControllerTest {
     @WithMockUser("COMPRICER")
     fun create_deprecated_house_quote() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val request = post("/v1/quotes")
             .with(user("compricer"))
@@ -217,7 +196,7 @@ internal class QuotesControllerTest {
     @WithMockUser("COMPRICER")
     fun create_norwegian_travel_quote() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val request = post("/v1/quotes")
             .with(user("compricer"))
@@ -236,7 +215,7 @@ internal class QuotesControllerTest {
     @WithMockUser("COMPRICER")
     fun create_norwegian_home_content_quote() {
 
-        every { quoteService.createQuote(any(), any()) } returns (Right(quoteResponse))
+        every { quoteService.createQuote(any(), any()) } returns quoteResponse
 
         val request = post("/v1/quotes")
             .with(user("compricer"))


### PR DESCRIPTION
# Jira Issue: [MX-191] 

## What?
- Add exception handler for `FeignException` which just passes on the upstream error if status is 4xx and a plain 500 error otherwise
- Don't use bimap to handle create quote

## Why?
- So Avy can get proper error messages when creating quotes

## Optional checklist
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally



[MX-191]: https://hedvig.atlassian.net/browse/MX-191